### PR TITLE
Enhance support for OTP Tokens 2FA and OpenSSL Integration

### DIFF
--- a/php-chroot-bind
+++ b/php-chroot-bind
@@ -4,12 +4,18 @@ _SYSTEMD_UNIT_DIR="/etc/systemd/system"
 _BIND="\
 	/usr/share/zoneinfo \
 	/dev/urandom \
+	/dev/random \
 	/dev/zero \
 	/dev/null \
 	/etc/resolv.conf \
+	/etc/hosts \
 	/lib/x86_64-linux-gnu/libnss_dns.so.2 \
 	/usr/share/ca-certificates \
-	/etc/ssl/certs"
+	/etc/ssl/certs \
+	/etc/ssl/openssl.cnf \
+	/usr/lib/ssl/openssl.cnf \
+	/usr/share/php \
+	/usr/bin"
 
 # File with additional binds for specific chroots. Relative to the chroot.
 _BIND_LOCAL="../bind.conf"


### PR DESCRIPTION
- Improved support for One-Time Password (OTP) tokens in Two-Factor Authentication (2FA).
- Enhanced integration with internal OpenSSL Library.

Regards, Kamal.